### PR TITLE
忽略 logs 文件夹 + 修复弃用警告

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config_*.json
 config.json
 .idea
 !utils/config_default.json
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,19 @@
+# IDE setting
+.DS_Store
+.vscode/
+.idea/
+venv/
+
+# Cache & binary & logs
 __pycache__
 cache/
-.vscode/
 build/
 dist/
-venv/
-.DS_Store
 *.build/
 *.dist/
+logs/
+
+# Config
 config_*.json
 config.json
-.idea
 !utils/config_default.json
-logs/

--- a/DD监控室.py
+++ b/DD监控室.py
@@ -509,7 +509,7 @@ class MainWindow(QMainWindow):
 
     def openCacheSizeSetting(self):
         userInputCache, okPressed = QInputDialog.getInt(self,"设置最大缓存大小","最大缓存(GB)",
-         float(self.config['maxCacheSize']) / (10 ** 6), 1, 4, 1)
+            int(float(self.config['maxCacheSize']) / (10 ** 6)), 1, 4, 1)
         if okPressed:
             self.config['maxCacheSize'] = int(userInputCache * 10 ** 6)
             self.dumpConfig.start()


### PR DESCRIPTION
`.gitignore` 就多加了个 logs 文件夹，然后分类整理了一下，所以显得修改较多。
