### PR TITLE
VLC3 重启player

### DIFF
--- a/DD监控室.py
+++ b/DD监控室.py
@@ -410,7 +410,7 @@ class MainWindow(QMainWindow):
             # pass
             self.videoWidgetList[self.videoIndex].mediaReload()
         else:
-            self.videoWidgetList[self.videoIndex].player.stop()
+            self.videoWidgetList[self.videoIndex].playerRestart()
         self.videoIndex += 1
 
     def addMedia(self, info):  # 窗口 房号

--- a/DD监控室.py
+++ b/DD监控室.py
@@ -676,12 +676,11 @@ class MainWindow(QMainWindow):
         self.layoutSettingPanel.close()
         self.liverPanel.addLiverRoomWidget.close()
         for videoWidget in self.videoWidgetList:
-            videoWidget.playerFree()  # 销毁实例
             videoWidget.getMediaURL.recordToken = False  # 关闭缓存并清除
             videoWidget.getMediaURL.checkTimer.stop()
             videoWidget.checkPlaying.stop()
+            videoWidget.close()
         for videoWidget in self.popVideoWidgetList:  # 关闭悬浮窗
-            videoWidget.playerFree()
             videoWidget.getMediaURL.recordToken = False
             videoWidget.getMediaURL.checkTimer.stop()
             videoWidget.checkPlaying.stop()

--- a/DD监控室.py
+++ b/DD监控室.py
@@ -676,12 +676,12 @@ class MainWindow(QMainWindow):
         self.layoutSettingPanel.close()
         self.liverPanel.addLiverRoomWidget.close()
         for videoWidget in self.videoWidgetList:
-            videoWidget.player.stop()
+            videoWidget.playerFree()  # 销毁实例
             videoWidget.getMediaURL.recordToken = False  # 关闭缓存并清除
             videoWidget.getMediaURL.checkTimer.stop()
             videoWidget.checkPlaying.stop()
         for videoWidget in self.popVideoWidgetList:  # 关闭悬浮窗
-            videoWidget.player.stop()
+            videoWidget.playerFree()
             videoWidget.getMediaURL.recordToken = False
             videoWidget.getMediaURL.checkTimer.stop()
             videoWidget.checkPlaying.stop()

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -856,14 +856,16 @@ class VideoWidget(QFrame):
         """重置 player
         vlc 实例（self.instance）保持不动
         """
-        self.player.stop()
+        if self.player:
+            self.player.stop()
         self.newPlayer()
         # 后续视频流设置由 GetMediaURL 发送 cacheName 信号执行 self.setMedia 完成
 
     def playerFree(self):
         """销毁 player 实例。退出主程序前调用"""
-        self.player.stop()
-        self.player.release()
+        if self.player:
+            self.player.stop()
+            self.player.release()
 
     def setTitle(self):
         if self.roomID == '0':

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -275,16 +275,7 @@ class VideoWidget(QFrame):
         layout.addWidget(self.videoFrame, 0, 0, 12, 12)
         # vlc 实例
         self.instance = vlc.Instance()
-        self.player = self.instance.media_player_new()  # 视频播放
-        self.player.video_set_mouse_input(False)
-        self.player.video_set_key_input(False)
-        # 将播放器实例绑定到 VideoFrame: QFrame
-        if platform.system() == 'Windows':
-            self.player.set_hwnd(self.videoFrame.winId())
-        elif platform.system() == 'Darwin':  # for MacOS
-            self.player.set_nsobject(int(self.videoFrame.winId()))
-        else:
-            self.player.set_xwindow(self.videoFrame.winId())
+        self.newPlayer()  # 实例化 player
 
         # 直播间标题
         self.topLabel = QLabel()
@@ -840,6 +831,21 @@ class VideoWidget(QFrame):
         self.player.play()
         self.moveTimer.start()  # 启动移动弹幕窗的timer
         self.checkPlaying.start(1000)  # 启动播放卡顿检测定时器
+
+    def newPlayer(self):
+        """实例化 player
+        依赖实例化的 vlc （self.instance）
+        """
+        self.player = self.instance.media_player_new()  # 视频播放
+        self.player.video_set_mouse_input(False)
+        self.player.video_set_key_input(False)
+        # 将播放器实例绑定到 VideoFrame: QFrame
+        if platform.system() == 'Windows':
+            self.player.set_hwnd(self.videoFrame.winId())
+        elif platform.system() == 'Darwin':  # for MacOS
+            self.player.set_nsobject(int(self.videoFrame.winId()))
+        else:
+            self.player.set_xwindow(self.videoFrame.winId())
 
     def setTitle(self):
         if self.roomID == '0':

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -229,8 +229,6 @@ class VideoWidget(QFrame):
                 self.setWindowTitle('%s %s' % (title, id + 1 - 9))
             else:
                 self.setWindowTitle('%s %s' % (title, id + 1))
-        if resize:
-            self.resize(resize[0], resize[1])
 
         layout = QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -353,6 +351,10 @@ class VideoWidget(QFrame):
         # 检查播放卡住的定时器
         self.checkPlaying = QTimer()
         self.checkPlaying.timeout.connect(self.checkPlayStatus)
+
+        # 最后再 resize 避免有变量尚未初始化
+        if resize:
+            self.resize(resize[0], resize[1])
         logging.info(f"{self.name_str} VLC 播放器构造完毕, 缓存大小: %dkb , 置顶?: %s, 启用弹幕?: %s" % (self.maxCacheSize, self.top, self.startWithDanmu))
 
     def checkPlayStatus(self):  # 播放卡住了

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -780,10 +780,9 @@ class VideoWidget(QFrame):
         self.getMediaURL.recordToken = False  # 设置停止缓存标志位
         self.getMediaURL.checkTimer.stop()
         self.checkPlaying.stop()
-        self.player.stop()
         if self.roomID != '0':
-            self.setTitle()  # 同时获取最新直播状态
             self.playerRestart()
+            self.setTitle()  # 同时获取最新直播状态
             if self.liveStatus == 1:  # 直播中
                 self.getMediaURL.setConfig(self.roomID, self.quality)  # 设置房号和画质
                 self.getMediaURL.start()  # 开始缓存视频
@@ -795,7 +794,7 @@ class VideoWidget(QFrame):
         self.roomID = '0'
         self.topLabel.setText(('    窗口%s  未定义的直播间' % (self.id + 1))[:20])  # 限制下直播间标题字数
         self.titleLabel.setText('未定义')
-        self.player.stop()
+        self.playerRestart()
         self.play.setIcon(self.style().standardIcon(QStyle.SP_MediaPlay))
         self.deleteMedia.emit(self.id)
         try:
@@ -849,10 +848,10 @@ class VideoWidget(QFrame):
             self.player.set_xwindow(self.videoFrame.winId())
 
     def playerRestart(self):
-        """用于 player.stop() 后重新实例化 player
+        """重置 player
         vlc 实例（self.instance）保持不动
         """
-        # 重新实例化 player
+        self.player.stop()
         self.newPlayer()
         # 后续视频流设置由 GetMediaURL 发送 cacheName 信号执行 self.setMedia 完成
 

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -832,6 +832,11 @@ class VideoWidget(QFrame):
         self.moveTimer.start()  # 启动移动弹幕窗的timer
         self.checkPlaying.start(1000)  # 启动播放卡顿检测定时器
 
+    """==== self.player 相关函数 ====
+    + newPlayer()       新实例化一个 self.player。初始化用
+    + playerRestart()   重置 self.player
+    + playerFree()      释放并销毁 playerFree 实例
+    """
     def newPlayer(self):
         """实例化 player
         依赖实例化的 vlc （self.instance）
@@ -854,6 +859,11 @@ class VideoWidget(QFrame):
         self.player.stop()
         self.newPlayer()
         # 后续视频流设置由 GetMediaURL 发送 cacheName 信号执行 self.setMedia 完成
+
+    def playerFree(self):
+        """销毁 player 实例。退出主程序前调用"""
+        self.player.stop()
+        self.player.release()
 
     def setTitle(self):
         if self.roomID == '0':

--- a/VideoWidget_vlc.py
+++ b/VideoWidget_vlc.py
@@ -780,9 +780,10 @@ class VideoWidget(QFrame):
         self.getMediaURL.recordToken = False  # 设置停止缓存标志位
         self.getMediaURL.checkTimer.stop()
         self.checkPlaying.stop()
-        self.player.pause()
+        self.player.stop()
         if self.roomID != '0':
             self.setTitle()  # 同时获取最新直播状态
+            self.playerRestart()
             if self.liveStatus == 1:  # 直播中
                 self.getMediaURL.setConfig(self.roomID, self.quality)  # 设置房号和画质
                 self.getMediaURL.start()  # 开始缓存视频
@@ -846,6 +847,14 @@ class VideoWidget(QFrame):
             self.player.set_nsobject(int(self.videoFrame.winId()))
         else:
             self.player.set_xwindow(self.videoFrame.winId())
+
+    def playerRestart(self):
+        """用于 player.stop() 后重新实例化 player
+        vlc 实例（self.instance）保持不动
+        """
+        # 重新实例化 player
+        self.newPlayer()
+        # 后续视频流设置由 GetMediaURL 发送 cacheName 信号执行 self.setMedia 完成
 
     def setTitle(self):
         if self.roomID == '0':

--- a/docs/vlc-player.md
+++ b/docs/vlc-player.md
@@ -1,0 +1,50 @@
+VLC 播放器调用
+==============
+
+仅描述在某个 QFrame 中调用 VLC 播放器的方法。
+
+
+## VLC 实例化 
+
+```python3
+self.instance = vlc.Instance()
+```
+
+## Player 实例化
+```python3
+self.player = self.instance.media_player_new()
+
+# 更多 self.player 的设置 ...
+
+# 绑定到 QFrame
+if platform.system() == "Linux": # for Linux using the X Server
+    self.mediaplayer.set_xwindow(int(self.videoframe.winId()))
+elif platform.system() == "Windows": # for Windows
+    self.mediaplayer.set_hwnd(int(self.videoframe.winId()))
+elif platform.system() == "Darwin": # for MacOS
+    self.mediaplayer.set_nsobject(int(self.videoframe.winId()))
+
+# 设置视频流来源
+self.mediaplayer.set_media(self.media)
+```
+
+## `self.player.stop()` 的问题
+`stop()` 之后 `self.player` 被设置为停止状态[^1][src-libvlc_media_player_stop]。
+再次启用时会出现无法单独控制音频的bug。
+因此需要重新实例化。
+
+官方的qt例子也是采用先 stop 然后重新实例化的方式[^2][src-qtplayer]。
+
+现在采用将 `stop()` 和重新实例化封装为一个函数的办法解决以上bug。
+参见：`VideoWidget.playerRestart()`
+
+
+[src-libvlc_media_player_stop]: https://code.videolan.org/videolan/vlc/-/blob/3.0.0-git/lib/media_player.c#L1045
+[src-qtplayer]: https://code.videolan.org/videolan/vlc/-/blob/3.0.0-git/doc/libvlc/QtPlayer/player.cpp#L119
+
+
+## 参考资料
++ [doc/libvlc/QtPlayer/player.cpp · 3.0.0-git · VideoLAN / VLC · GitLab]( https://code.videolan.org/videolan/vlc/-/blob/3.0.0-git/doc/libvlc/QtPlayer/player.cpp )
+    VLC 官方的 Qt 例子
++ [python-vlc/pyqt5vlc.py at master · oaubert/python-vlc]( https://github.com/oaubert/python-vlc/blob/master/examples/pyqt5vlc.py )
+    python-vlc 的 PyQt 例子

--- a/hooks/hook-vlc.py
+++ b/hooks/hook-vlc.py
@@ -21,7 +21,7 @@ plugins_dlls = [
     ('audio_mixer', 'libfloat_mixer_plugin'),
 
     ('video_chroma', 'libswscale_plugin'),
-    ('video_output', 'libdirect3d_plugin'),
+    ('video_output', 'libdirect3d11_plugin'),
     ('video_output', 'libdrawable_plugin'),
     ('video_output', 'libdirectdraw_plugin'),
 ]

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,4 +1,6 @@
 @echo off
+RMDIR /S /Q dist
+RMDIR /S /Q build
 pyinstaller --clean --noconfirm DDMonitor.spec
 mkdir dist\DDMonitor\logs
 copy utils\config_default.json dist\DDMonitor\utils\config.json


### PR DESCRIPTION
+ 将 player 实例化包装为函数
+ 在 stop之后重新实例化 player
+ 封装 stop 函数确保与 newPlayer 配对使用
+ 使用 `playerRestart()` 替代 `player.stop`
+ 直接使用直接调用 `VideoWidget.close()` 方法，避免多次关闭 player
+ 添加 `playerFree` 方法用于销毁 player
+ 添加对 player 的说明文档
+ 更新 vlc3.0 dll 依赖
